### PR TITLE
Add clone2local command for sparse repo cloning

### DIFF
--- a/bash2gitlab/__main__.py
+++ b/bash2gitlab/__main__.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from bash2gitlab import __about__
 from bash2gitlab import __doc__ as root_doc
+from bash2gitlab.clone2local import clone2local_handler
 from bash2gitlab.compile_all import process_uncompiled_directory
 from bash2gitlab.config import config
 from bash2gitlab.init_project import init_handler
@@ -207,6 +208,26 @@ def main() -> int:
     shred_parser.add_argument("-q", "--quiet", action="store_true", help="Disable output.")
     shred_parser.set_defaults(func=shred_handler)
 
+    # --- clone2local Command ---
+    clone_parser = subparsers.add_parser(
+        "clone2local", help="Clone a repository using sparse checkout.",
+    )
+    clone_parser.add_argument(
+        "--repo-url", required=True, help="Repository URL to clone.",
+    )
+    clone_parser.add_argument(
+        "--clone-dir", required=True, help="Destination directory for the clone.",
+    )
+    clone_parser.add_argument(
+        "--sparse-dirs",
+        nargs="+",
+        required=True,
+        help="Directories to include in the sparse checkout.",
+    )
+    clone_parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose (DEBUG) logging output.")
+    clone_parser.add_argument("-q", "--quiet", action="store_true", help="Disable output.")
+    clone_parser.set_defaults(func=clone2local_handler)
+
     # Init Parser
     init_parser = subparsers.add_parser(
         "init",
@@ -262,7 +283,8 @@ def main() -> int:
     args.quiet = args.quiet or config.quiet or False
     if hasattr(args, "format"):
         args.format = args.format or config.format or False
-    args.dry_run = args.dry_run or config.dry_run or False
+    if hasattr(args, "dry_run"):
+        args.dry_run = args.dry_run or config.dry_run or False
 
     # --- Setup Logging ---
     if args.verbose:

--- a/bash2gitlab/clone2local.py
+++ b/bash2gitlab/clone2local.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+
+def clone_repository(repo_url: str, sparse_dirs: Sequence[str], clone_dir: str | Path) -> None:
+    """Clone a repository using Git's sparse checkout.
+
+    Parameters
+    ----------
+    repo_url:
+        The URL of the repository to clone.
+    sparse_dirs:
+        Iterable of directories to include in the sparse checkout.
+    clone_dir:
+        Destination directory for the clone.
+    """
+    clone_path = Path(clone_dir)
+    logger.debug(
+        "Cloning repo %s into %s with sparse dirs %s", repo_url, clone_path, list(sparse_dirs)
+    )
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            "--sparse",
+            repo_url,
+            str(clone_path),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "sparse-checkout", "init", "--cone"],
+        cwd=clone_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "sparse-checkout", "set", *sparse_dirs],
+        cwd=clone_path,
+        check=True,
+    )
+
+def clone2local_handler(args) -> None:
+    """Argparse handler for the clone2local command."""
+    clone_repository(args.repo_url, args.sparse_dirs, args.clone_dir)

--- a/test/test_clone2local.py
+++ b/test/test_clone2local.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import subprocess
+
+from bash2gitlab.clone2local import clone_repository
+
+def test_clone_repository_calls_git(monkeypatch):
+    calls: List[dict] = []
+
+    def fake_run(cmd, *_, **kwargs):
+        calls.append({"cmd": cmd, "cwd": kwargs.get("cwd"), "check": kwargs.get("check")})
+        class Dummy:
+            returncode = 0
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    repo_url = "https://example.com/repo.git"
+    sparse_dirs = ["dir1", "dir2"]
+    clone_dir = Path("clone")
+
+    clone_repository(repo_url, sparse_dirs, clone_dir)
+
+    assert calls[0]["cmd"] == [
+        "git",
+        "clone",
+        "--depth",
+        "1",
+        "--filter=blob:none",
+        "--sparse",
+        repo_url,
+        str(clone_dir),
+    ]
+    assert calls[0]["check"] is True
+    assert calls[1]["cmd"] == ["git", "sparse-checkout", "init", "--cone"]
+    assert calls[1]["cwd"] == clone_dir
+    assert calls[2]["cmd"] == ["git", "sparse-checkout", "set", *sparse_dirs]
+    assert calls[2]["cwd"] == clone_dir


### PR DESCRIPTION
## Summary
- remove default repo, clone directory and sparse paths from sparse clone helper
- require repo URL, destination directory and sparse paths for `clone2local` CLI subcommand

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling (proxy 403))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'ruamel')*


------
https://chatgpt.com/codex/tasks/task_e_688e27d699ec8327a6ce699031fa83de