### PR TITLE
feat: add compile parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See [extended examples here](https://github.com/matthewdeanmartin/bash2gitlab/tr
 ```bash
 ❯ bash2gitlab compile --help
 usage: bash2gitlab compile [-h] --in INPUT_DIR --out OUTPUT_DIR [--scripts SCRIPTS_DIR] [--templates-in TEMPLATES_IN]
-                           [--templates-out TEMPLATES_OUT] [--format] [-v]
+                           [--templates-out TEMPLATES_OUT] [--parallelism PARALLELISM] [-v]
 
 options:
   -h, --help            show this help message and exit
@@ -86,7 +86,8 @@ options:
                         Input directory for CI templates. (Default: <in>)
   --templates-out TEMPLATES_OUT
                         Output directory for compiled CI templates. (Default: <out>)
-  --format              Format all output YAML files using 'yamlfix'. Requires yamlfix to be installed.
+  --parallelism PARALLELISM
+                        Number of files to compile in parallel (default: CPU count).
   -v, --verbose         Enable verbose (DEBUG) logging output.
 ```
 

--- a/bash2gitlab/__main__.py
+++ b/bash2gitlab/__main__.py
@@ -50,6 +50,7 @@ def compile_handler(args: argparse.Namespace):
     templates_in_dir = Path(args.templates_in).resolve() if args.templates_in else in_dir
     templates_out_dir = Path(args.templates_out).resolve() if args.templates_out else out_dir
     dry_run = bool(args.dry_run)
+    parallelism = args.parallelism
 
     if args.watch:
         start_watch(
@@ -59,6 +60,7 @@ def compile_handler(args: argparse.Namespace):
             templates_dir=templates_in_dir,
             output_templates_dir=templates_out_dir,
             dry_run=dry_run,
+            parallelism=parallelism,
         )
         return
 
@@ -70,6 +72,7 @@ def compile_handler(args: argparse.Namespace):
             templates_dir=templates_in_dir,
             output_templates_dir=templates_out_dir,
             dry_run=dry_run,
+            parallelism=parallelism,
         )
 
 
@@ -156,6 +159,12 @@ def main() -> int:
     compile_parser.add_argument(
         "--templates-out",
         help="Output directory for compiled CI templates. (Default: <out>)",
+    )
+    compile_parser.add_argument(
+        "--parallelism",
+        type=int,
+        default=config.parallelism,
+        help="Number of files to compile in parallel (default: CPU count).",
     )
     compile_parser.add_argument(
         "--dry-run",

--- a/bash2gitlab/config.py
+++ b/bash2gitlab/config.py
@@ -116,6 +116,26 @@ class _Config:
 
         return None
 
+    def _get_int(self, key: str) -> int | None:
+        """Gets an integer value, respecting precedence."""
+        value = self._env_config.get(key)
+        if value is not None:
+            try:
+                return int(value)
+            except ValueError:
+                logger.warning(f"Config value for '{key}' is not an int. Ignoring.")
+                return None
+
+        value = self._file_config.get(key)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                logger.warning(f"Config value for '{key}' is not an int. Ignoring.")
+                return None
+
+        return None
+
     # --- Compile Command Properties ---
     @property
     def input_dir(self) -> str | None:
@@ -136,6 +156,10 @@ class _Config:
     @property
     def templates_out(self) -> str | None:
         return self._get_str("templates_out")
+
+    @property
+    def parallelism(self) -> int | None:
+        return self._get_int("parallelism")
 
     # --- Shred Command Properties ---
     @property

--- a/bash2gitlab/init_project.py
+++ b/bash2gitlab/init_project.py
@@ -13,8 +13,6 @@ DEFAULT_CONFIG = {
     "scripts_dir": "scripts",
     "templates_in": "templates",
     "templates_out": "out/templates",
-    "verbose":"false"
-
 }
 
 # Default settings for boolean flags
@@ -93,6 +91,9 @@ def create_config_file(base_path: Path, config: dict[str, Any], dry_run: bool = 
     # Write the config file
     # Lowercase boolean values for TOML compatibility
     formatted_config = config.copy()
+    # Ensure required flags are present
+    for key, default in DEFAULT_FLAGS.items():
+        formatted_config.setdefault(key, default)
     for key, value in formatted_config.items():
         if isinstance(value, bool):
             formatted_config[key] = str(value).lower()

--- a/bash2gitlab/watch_files.py
+++ b/bash2gitlab/watch_files.py
@@ -43,6 +43,7 @@ class _RecompileHandler(FileSystemEventHandler):
         templates_dir: Path,
         output_templates_dir: Path,
         dry_run: bool = False,
+        parallelism: int | None = None,
     ) -> None:
         super().__init__()
         self._paths = {
@@ -52,7 +53,7 @@ class _RecompileHandler(FileSystemEventHandler):
             "templates_dir": templates_dir,
             "output_templates_dir": output_templates_dir,
         }
-        self._flags = {"dry_run": dry_run}
+        self._flags = {"dry_run": dry_run, "parallelism": parallelism}
         self._debounce: float = 0.5  # seconds
         self._last_run = 0.0
 
@@ -86,6 +87,7 @@ def start_watch(
     templates_dir: Path,
     output_templates_dir: Path,
     dry_run: bool = False,
+    parallelism: int | None = None,
 ) -> None:
     """
     Start an in-process watchdog that recompiles whenever source files change.
@@ -99,6 +101,7 @@ def start_watch(
         templates_dir=templates_dir,
         output_templates_dir=output_templates_dir,
         dry_run=dry_run,
+        parallelism=parallelism,
     )
 
     observer = Observer()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ options:
 ```bash
 ❯ bash2gitlab compile --help
 usage: bash2gitlab compile [-h] --in INPUT_DIR --out OUTPUT_DIR [--scripts SCRIPTS_DIR] [--templates-in TEMPLATES_IN]
-                           [--templates-out TEMPLATES_OUT] [--format] [--dry-run] [-v] [-q]
+                           [--templates-out TEMPLATES_OUT] [--parallelism PARALLELISM] [--dry-run] [-v] [-q]
 
 options:
   -h, --help            show this help message and exit
@@ -42,7 +42,8 @@ options:
                         Input directory for CI templates. (Default: <in>)
   --templates-out TEMPLATES_OUT
                         Output directory for compiled CI templates. (Default: <out>)
-  --format              Format all output YAML files using 'yamlfix'. Requires yamlfix to be installed.
+  --parallelism PARALLELISM
+                        Number of files to compile in parallel (default: CPU count).
   --dry-run             Simulate the compilation process without writing any files.
   -v, --verbose         Enable verbose (DEBUG) logging output.
   -q, --quiet           Disable output.


### PR DESCRIPTION
## Summary
- add optional parallelism control for compile command and config
- enable multiprocessing-based compilation when processing many files
- support parallelism in watch mode and project config generation

## Testing
- `pytest`
- `pre-commit run --files README.md bash2gitlab/__main__.py bash2gitlab/compile_all.py bash2gitlab/config.py bash2gitlab/init_project.py bash2gitlab/watch_files.py docs/usage.md`

------
https://chatgpt.com/codex/tasks/task_e_688e6a169ac48327a30815f951686abe